### PR TITLE
Exercise 7: Adjust incorrect markdown - polynomial to poly

### DIFF
--- a/07. Advanced SVMs - Python.ipynb
+++ b/07. Advanced SVMs - Python.ipynb
@@ -215,7 +215,7 @@
     {
       "metadata": {},
       "cell_type": "markdown",
-      "source": "Perhaps a sigmoid kernel isn't a good idea for this data set....\n\nLets try a polynomial kernel\n\n#### Replace `<replaceWithPoly>` with `'polynomial'` then run the cell."
+      "source": "Perhaps a sigmoid kernel isn't a good idea for this data set....\n\nLets try a polynomial kernel\n\n#### Replace `<replaceWithPoly>` with `'poly'` then run the cell."
     },
     {
       "metadata": {


### PR DESCRIPTION
Adjust incorrect markdown in Exercise 7. 

It currently reads "Replace <replaceWithPoly> with 'polynomial' then run the cell"

However, the code correctly reads:

###
# REPLACE THE <replaceWithPoly> BELOW WITH 'poly' (INCLUDING THE QUOTES)
###

Updating the markdwon to show correctly.